### PR TITLE
Issue #62: Added execute Docker command task and Docker image prune after build

### DIFF
--- a/tasks.gradle
+++ b/tasks.gradle
@@ -246,6 +246,52 @@ task copyComposeFiles {
 
     }
 }
+ext.executeDockerCommand = { String shellCmd ->
+    println "Checking if Docker is running..."
+
+    def dockerRunning = false
+    try {
+        def process = new ProcessBuilder("docker", "info")
+                .redirectErrorStream(true)
+                .start()
+        if (!process.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
+            println "Docker command timed out, assuming Docker is not running."
+            process.destroyForcibly()
+        } else if (process.exitValue() == 0) {
+            dockerRunning = true
+        }
+    } catch (Exception e) {
+        println "Error checking Docker: ${e.message}"
+    }
+    if (!dockerRunning) {
+        throw new GradleException("Docker is not running. Please start the Docker service.")
+    }
+    def output = new ByteArrayOutputStream()
+    println "⚙️ Executing Docker command: ${shellCmd}"
+    def osCmd = Os.isFamily(Os.FAMILY_WINDOWS)
+      ? ['cmd','/c', shellCmd]
+      : ['bash','-lc', shellCmd]
+    def result = exec {
+        commandLine osCmd
+        standardOutput = output
+        errorOutput = output
+        ignoreExitValue = true
+    }
+    if (result.exitValue != 0) {
+        throw new GradleException("The command fails:\n" + output.toString())
+    }
+    // store in build/compose/logs the output of the last successful command
+    def logsDir = file("$composeDir/logs")
+    if (!logsDir.exists()) {
+        logsDir.mkdirs()
+    }
+    // get current timestamp to add it to the log file name
+    def timestamp = new Date().format("yyyyMMdd_HHmmss")
+    // create the log file with the timestamp
+    def logFile = file("$logsDir/build-timestamp-${timestamp}.log")
+    logFile.text = output.toString()
+    println output.toString()
+}
 
 ext.executeDockerComposeCommand = { String action ->
     def composeFiles = fileTree(dir: composeDir, include: '*.yml').files
@@ -330,6 +376,7 @@ task "resources.up" {
 
     doLast {
         executeDockerComposeCommand('up -d --build')
+        executeDockerCommand('docker image prune -f')
     }
 }
 
@@ -360,6 +407,7 @@ task "resources.build" {
 
     doLast {
         executeDockerComposeCommand('build --no-cache')
+        executeDockerCommand('docker image prune -f')
     }
 }
 
@@ -370,7 +418,7 @@ afterEvaluate {
     tasks.named("compile.complete").configure { task ->
         task.dependsOn("copyComposeFiles")
     }
-    tasks.named("resources.up").configure {
-        mustRunAfter("resources.build")
+    tasks.named("resources.build").configure {
+        finalizedBy("resources.up")
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to Docker command execution and resource management in the Gradle build process, focusing on ensuring Docker is running before executing commands, logging Docker command outputs, and optimizing the build task order for better reliability and cleanup.

**Enhancements to Docker command execution and resource management:**

*Docker command execution and logging:*
- Added a new `executeDockerCommand` closure that checks if Docker is running before executing any Docker command, captures and logs the output (with timestamps) in the `build/compose/logs` directory, and provides clear error messages if Docker is not available.

*Resource cleanup:*
- Updated the `"resources.up"` and `"resources.build"` tasks to run `docker image prune -f` after their main actions, ensuring unused Docker images are cleaned up automatically after these tasks. [[1]](diffhunk://#diff-60fdffcf350ecafe33145fbc861c9a8c1e1928c0eddb028b64fe9c91a0e63c89R379) [[2]](diffhunk://#diff-60fdffcf350ecafe33145fbc861c9a8c1e1928c0eddb028b64fe9c91a0e63c89R410)

*Build task orchestration:*
- Changed the build task order so that `"resources.build"` is now finalized by `"resources.up"`, ensuring that resources are always brought up after a build completes, rather than requiring manual sequencing.