### PR TITLE
Issue #91: Update compiler image version from 1.0.6 to 1.0.7

### DIFF
--- a/pipelines/Jenkinsfile
+++ b/pipelines/Jenkinsfile
@@ -65,7 +65,7 @@ spec:
       emptyDir: {}           # local cache images for dind
   containers:
     - name: compiler
-      image: etendo/compiler_jenkins:1.0.6
+      image: etendo/compiler_jenkins:1.0.7
       env:
         - name: DOCKER_HOST
           value: tcp://localhost:2375


### PR DESCRIPTION
## Summary

- Updates `etendo/compiler_jenkins` image from `1.0.6` to `1.0.7` in the Jenkins pipeline configuration.

## Related

- Jira: [ETP-3614](https://etendoproject.atlassian.net/browse/ETP-3614)
- GitHub Issue: etendosoftware/com.etendoerp.platform.extensions#91

[ETP-3614]: https://etendoproject.atlassian.net/browse/ETP-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ