### PR TITLE
Issue #38: Refactor Docker module Jenkins pipeline: fix etendo-core version range, update Java 17, extract stack config

### DIFF
--- a/pipelines/Jenkinsfile
+++ b/pipelines/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
     FAILED   = 'FAILED'
     UNSTABLE = 'UNSTABLE'
 
-    NEXT_CLASSIC_VERSION = '25.3.0'
+    NEXT_CLASSIC_VERSION = '26.2.0'
     BASE_BRANCH_BACKPORT = "release/24.4"
     MAIN_BRANCH          = "main"
   }

--- a/pipelines/Jenkinsfile
+++ b/pipelines/Jenkinsfile
@@ -25,10 +25,8 @@ pipeline {
     ETENDO_BASE_URL   = 'https://github.com/etendosoftware/etendo_base'
     DOCKER_MODULE_URL = 'https://github.com/etendosoftware/com.etendoerp.docker'
 
-    TOMCAT_URL      = 'https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.98/bin/apache-tomcat-9.0.98.tar.gz'
-    JAVA_HOME       = '/usr/lib/jvm/java-17-openjdk-amd64'
-    MODULE_PACKAGE  = 'com.etendoerp.docker'
-    ETENDO_BASE     = 'etendo_base'
+    MODULE_PACKAGE = 'com.etendoerp.docker'
+    ETENDO_BASE    = 'etendo_base'
 
     COMMIT_INPROGRESS_STATUS = 'pending'
     COMMIT_SUCCESS_STATUS    = 'success'
@@ -38,89 +36,24 @@ pipeline {
     FAILED   = 'FAILED'
     UNSTABLE = 'UNSTABLE'
 
-    NEXT_CLASSIC_VERSION = '26.2.0'
-    BASE_BRANCH_BACKPORT = "release/24.4"
-    MAIN_BRANCH          = "main"
+    TRUE  = 'true'
+    FALSE = 'false'
+
+    MAIN_BRANCH = 'main'
+
+    // Stack variables — configure these in the Jenkins job environment, not here:
+    //   JAVA_HOME_DEFAULT, JAVA_HOME_BACKPORT
+    //   TOMCAT_URL_DEFAULT, TOMCAT_URL_BACKPORT
+    //   NEXT_CLASSIC_VERSION_DEFAULT, NEXT_CLASSIC_VERSION_BACKPORT
+    //   BASE_CORE_VERSION
+    //   BACKPORT_BRANCH
   }
 
   agent { // MARK: - Agent
     kubernetes {
       inheritFrom 'jenkins-node-rx'
       defaultContainer 'jnlp'
-      yaml """
-apiVersion: v1
-kind: Pod
-metadata:
-  name: jenkins-node-pg-0
-  namespace: jenkins2025
-  labels:
-    app.kubernetes.io/name: jenkins-node-pg
-spec:
-  volumes:
-    - name: rsa-keys
-      configMap:
-        name: rsa-keys
-        defaultMode: 384
-    - name: dind-storage
-      emptyDir: {}           # local cache images for dind
-  containers:
-    - name: compiler
-      image: etendo/compiler_jenkins:1.0.6
-      env:
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
-      securityContext:
-        privileged: true
-        runAsUser: 0
-      ports:
-        - name: ssh
-          containerPort: 22
-          protocol: TCP
-        - name: visualvm
-          containerPort: 8000
-          protocol: TCP
-      resources:
-        requests:
-          cpu: 1072m
-          memory: 4000Mi
-        limits:
-          cpu: 2072m
-          memory: 6500Mi
-      volumeMounts:
-        - name: rsa-keys
-          mountPath: /root/.ssh/
-      lifecycle:
-        postStart:
-          exec:
-            command:
-              - bash
-              - -lc
-              - |
-                set -e
-                apt-get update -y
-                command -v docker >/dev/null || apt-get install -y docker.io
-                apt-get install -y curl
-      imagePullPolicy: IfNotPresent
-    - name: dind
-      image: docker:25-dind
-      securityContext:
-        privileged: true
-      env:
-        - name: DOCKER_TLS_CERTDIR
-          value: ""            # without TLS inside the pod
-      args:
-        - --mtu=1450           # adjust if your CNI requires it
-        - --storage-driver=overlay2
-      volumeMounts:
-        - name: dind-storage
-          mountPath: /var/lib/docker
-  restartPolicy: Always
-  terminationGracePeriodSeconds: 30
-  dnsPolicy: ClusterFirst
-  serviceAccountName: default
-  serviceAccount: default
-  securityContext: {}
-  """
+      yamlFile 'pipelines/utils/Agent.yaml'
     }
   }
 
@@ -157,7 +90,64 @@ spec:
         }
       }
     }
-    stage ('Build Enviroment') { // MARK: - Build Environment
+
+    stage('Stack Configuration') { // MARK: - Stack Configuration
+      when {
+        expression { currentBuild.result == SUCCESS }
+      }
+      steps {
+        container('compiler') {
+          script {
+            try {
+              echo '---------------- Determining branch type ----------------'
+              env.FROM_BACKPORT = FALSE
+              if (env.GIT_BRANCH.contains('-Y') || env.GIT_BRANCH.startsWith('release')) {
+                env.FROM_BACKPORT = TRUE
+              }
+
+              echo '---------------- Resolving stack configuration ----------------'
+              def rootDir = pwd()
+              def stackConfig = load "${rootDir}/pipelines/utils/stackConfig.groovy"
+              def stackConfiguration = stackConfig.resolveStackConfiguration(env.FROM_BACKPORT)
+
+              env.JAVA_HOME           = stackConfiguration.javaHome
+              env.TOMCAT_URL          = stackConfiguration.tomcatUrl
+              env.NEXT_CLASSIC_VERSION = stackConfiguration.nextClassicVersion
+              env.BASE_CORE_VERSION   = stackConfiguration.baseCoreVersion
+              env.STACK_TYPE          = stackConfiguration.stackType
+
+              env.BASE_BRANCH = env.MAIN_BRANCH
+              if (env.FROM_BACKPORT == TRUE) {
+                env.BASE_BRANCH = env.BACKPORT_BRANCH
+              }
+
+              echo "Stack Type:           ${env.STACK_TYPE}"
+              echo "Java Home:            ${env.JAVA_HOME}"
+              echo "Tomcat URL:           ${env.TOMCAT_URL}"
+              echo "Next Classic Version: ${env.NEXT_CLASSIC_VERSION}"
+              echo "Base Core Version:    ${env.BASE_CORE_VERSION}"
+              echo "Base Branch:          ${env.BASE_BRANCH}"
+
+              sh "wget -O apache-tomcat.tar.gz ${env.TOMCAT_URL}"
+              sh "tar -xvf apache-tomcat.tar.gz -C ${WORKSPACE} > /dev/null 2>&1"
+
+              env.TOMCAT_FOLDER = stackConfig.getTomcatFolder()
+              env.CATALINA_HOME = "${WORKSPACE}/${env.TOMCAT_FOLDER}"
+              env.CATALINA_BASE = "${WORKSPACE}/${env.TOMCAT_FOLDER}"
+
+              currentBuild.result = SUCCESS
+            } catch (Exception e) {
+              echo '---------------- Stack Configuration Failed ----------------'
+              echo "Exception occurred: " + e.toString()
+              currentBuild.result = FAILED
+              error('Stack Configuration Failed')
+            }
+          }
+        }
+      }
+    }
+
+    stage('Build Environment') { // MARK: - Build Environment
       when {
         expression { currentBuild.result == SUCCESS }
       }
@@ -167,23 +157,12 @@ spec:
             try {
               sh "./pipelines/utils/build-update.sh ${MODULE_PACKAGE} ${COMMIT_INPROGRESS_STATUS} \"Starting build\" ${ACCESS_TOKEN} ${GIT_COMMIT} ${BUILD_URL} \"${CONTEXT_BUILD}\""
 
-              echo '---------------- Choice of etendo_base branch ----------------'
-              env.BASE_BRANCH = env.MAIN_BRANCH
-              if (env.GIT_BRANCH.contains("-Y") || env.GIT_BRANCH.startsWith("release")) {
-                  env.BASE_BRANCH = env.BASE_BRANCH_BACKPORT
-              }
-
               echo '--------------- Building Etendo environment ----------------'
               sh "git clone ${ETENDO_BASE_URL}"
 
-              echo "--------------- Building Etendo environment ----------------"
-
-              sh "wget -O apache-tomcat.tar.gz ${TOMCAT_URL}"
-              sh "tar -xvf apache-tomcat.tar.gz -C ${WORKSPACE} > /dev/null 2>&1"
-
-              env.TOMCAT_FOLDER = sh(script: "basename ${TOMCAT_URL} .tar.gz", returnStdout: true).trim()
-              env.CATALINA_HOME = "${WORKSPACE}/${TOMCAT_FOLDER}"
-              env.CATALINA_BASE = "${WORKSPACE}/${TOMCAT_FOLDER}"
+              def rootDir = pwd()
+              def stackConfig = load "${rootDir}/pipelines/utils/stackConfig.groovy"
+              def javaVersion = stackConfig.getJavaVersionNumber()
 
               sh """
               cd ${ETENDO_BASE}
@@ -207,20 +186,20 @@ spec:
               db.base.memory.mb=10240
               org.gradle.jvmargs=-Dfile.encoding=UTF-8
               org.gradle.daemon=false
-              java.version=17" > gradle.properties
+              java.version=${javaVersion}" > gradle.properties
               """
 
               echo '---------------- Add dependencies ----------------'
-
               def buildGradleContent = """
                 dependencies {
-                    implementation(\"com.etendoerp.platform:etendo-core:[24.4.0,${NEXT_CLASSIC_VERSION})\")
+                    implementation(\"com.etendoerp.platform:etendo-core:[${env.BASE_CORE_VERSION},${env.NEXT_CLASSIC_VERSION})\")
                 }
               """
               sh """
               cd ${ETENDO_BASE}
               echo '${buildGradleContent}' >> build.gradle
               """
+
               echo '---------------- Verifying Docker Containers ----------------'
               sh '''
                 bash -lc '
@@ -231,6 +210,7 @@ spec:
                   docker run --rm hello-world
                 '
               '''
+
               echo '---------------- Build & Compile ----------------'
               sh """
                 cd ${ETENDO_BASE}
@@ -244,6 +224,7 @@ spec:
                 ./gradlew setup
                 ./gradlew resources.up --info
               """
+
               def pgIp = sh(
                 script: "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' etendo-db-1",
                 returnStdout: true
@@ -251,9 +232,8 @@ spec:
               def confFile = "${ETENDO_BASE}/gradle.properties"
               sh """
                 echo Postgres IP: ${pgIp}
-                # Replace or add dbdd.url
                 if grep -q '^bbdd.url=' ${confFile}; then
-                  sed -i  "s|^bbdd.url=.*|bbdd.url=jdbc:postgresql://${pgIp}:${BBDD_PORT}|" ${confFile}
+                  sed -i "s|^bbdd.url=.*|bbdd.url=jdbc:postgresql://${pgIp}:${BBDD_PORT}|" ${confFile}
                 else
                   echo "bbdd.url=jdbc:postgresql://${pgIp}:${BBDD_PORT}" >> ${confFile}
                 fi
@@ -265,22 +245,23 @@ spec:
               sleep time: 15, unit: 'SECONDS'
               def dockerPsOutput = sh(script: 'docker ps', returnStdout: true)
               echo "${dockerPsOutput}"
-              if (!dockerPsOutput.contains("etendo-db-1")) {
+              if (!dockerPsOutput.contains('etendo-db-1')) {
                 error('The etendo-db-1 container is not running')
               }
-              echo "Docker Containers are running"
+              echo 'Docker Containers are running'
 
               sh """
                 cd ${ETENDO_BASE}
                 ./gradlew install
-                ./gradlew smartbuild
+                ./gradlew smartbuild -PignoreConsistency=true
               """
-              sh "${WORKSPACE}/${TOMCAT_FOLDER}/bin/catalina.sh start"
-              def timeout = 60 // Timeout in seconds
-              def interval = 5 // Interval between checks in seconds
+
+              sh "${WORKSPACE}/${env.TOMCAT_FOLDER}/bin/catalina.sh start"
+              def timeout = 60
+              def interval = 5
               def elapsed = 0
               def tomcatReady = false
-              def tomcatResponse = "";
+              def tomcatResponse = ''
               def url = "http://localhost:8080/${CONTEXT_NAME}/security/Login_FS.html"
               while (elapsed < timeout) {
                 try {
@@ -290,14 +271,12 @@ spec:
                   ).trim()
                   echo "Tomcat response code: ${tomcatResponse}"
                 } catch (e) {
-                  tomcatResponse = "000"
+                  tomcatResponse = '000'
                 }
-
-                if (tomcatResponse == "200") {
+                if (tomcatResponse == '200') {
                   tomcatReady = true
                   break
                 }
-
                 echo "Tomcat not ready yet. Response code: ${tomcatResponse}. Retrying in ${interval} seconds..."
                 sleep interval
                 elapsed += interval
@@ -305,13 +284,12 @@ spec:
               if (!tomcatReady) {
                 error("Tomcat did not start within the timeout period of ${timeout} seconds.")
               }
-              echo "Tomcat response code: ${tomcatResponse}"
-              if (tomcatResponse != "200") {
+              if (tomcatResponse != '200') {
                 error("Tomcat did not respond with 200. Response code: ${tomcatResponse}")
               }
 
-              echo "-------------------- Stopping Tomcat --------------------"
-              sh "${WORKSPACE}/${TOMCAT_FOLDER}/bin/catalina.sh stop"
+              echo '-------------------- Stopping Tomcat --------------------'
+              sh "${WORKSPACE}/${env.TOMCAT_FOLDER}/bin/catalina.sh stop"
 
               sh """
               cd ${ETENDO_BASE}
@@ -321,7 +299,7 @@ spec:
               sleep time: 30, unit: 'SECONDS'
               dockerPsOutput = sh(script: 'docker ps', returnStdout: true)
               echo "${dockerPsOutput}"
-              if (dockerPsOutput.contains("etendo-db-1") && !dockerPsOutput.contains("Exited")) {
+              if (dockerPsOutput.contains('etendo-db-1') && !dockerPsOutput.contains('Exited')) {
                 error('The etendo-db-1 container still running')
               }
               currentBuild.result = SUCCESS
@@ -347,7 +325,6 @@ spec:
               cd ${ETENDO_BASE}
               ./gradlew resources.down
             """
-
           } catch (Exception e) {
             echo "⚠️ Cleanup failed: ${e.getMessage()}"
           }
@@ -378,9 +355,7 @@ spec:
           <body>
               <p><em>${new Date()}</em></p>
               <p>__________________________________________________________</p>
-
               <h2 class="header">✅ ERRORS FIXED ✅</h2>
-
               <p>
                   <strong>Commit:</strong> <a href="${DOCKER_MODULE_URL}/commits/${env.GIT_COMMIT}">${DOCKER_MODULE_URL}/commits/${env.GIT_COMMIT}</a><br />
                   <strong>Author:</strong> ${COMMIT_AUTHOR_NAME} (${COMMIT_AUTHOR_EMAIL})
@@ -396,6 +371,7 @@ spec:
       </html>
       """
     }
+
     failure {
       container('compiler') {
         script {
@@ -405,7 +381,7 @@ spec:
       mail to: EMAIL_ADDRESS,
       subject: "⛔ ERROR - ${currentBuild.fullDisplayName}",
       mimeType: 'text/html',
-      body:  """
+      body: """
       <html>
           <head>
               <style>
@@ -416,9 +392,7 @@ spec:
           <body>
               <p><em>${new Date()}</em></p>
               <p>__________________________________________________________</p>
-
               <h2 class="header">🚫 BUILD FAILED 🚫</h2>
-
               <p>
                   <strong>Commit:</strong> <a href="${DOCKER_MODULE_URL}/commits/${env.GIT_COMMIT}">${DOCKER_MODULE_URL}/commits/${env.GIT_COMMIT}</a><br />
                   <strong>Author:</strong> ${COMMIT_AUTHOR_NAME} (${COMMIT_AUTHOR_EMAIL})
@@ -426,10 +400,12 @@ spec:
               <p>
                   The build has failed unexpectedly.<br />
                   💡 This build was on the ${MODULE_PACKAGE} module.<br />
-                  To more information on the failing run visit:<br />
+                  For more information on the failing run visit:<br />
                   <a href="${env.BUILD_URL}">${env.BUILD_URL}</a>
               </p>
-      __________________________________________________________
+              <p>__________________________________________________________</p>
+          </body>
+      </html>
       """
     }
   }

--- a/pipelines/Jenkinsfile
+++ b/pipelines/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     DOCKER_MODULE_URL = 'https://github.com/etendosoftware/com.etendoerp.docker'
 
     TOMCAT_URL      = 'https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.98/bin/apache-tomcat-9.0.98.tar.gz'
-    JAVA_HOME       = '/usr/lib/jvm/java-11-openjdk-amd64'
+    JAVA_HOME       = '/usr/lib/jvm/java-17-openjdk-amd64'
     MODULE_PACKAGE  = 'com.etendoerp.docker'
     ETENDO_BASE     = 'etendo_base'
 
@@ -207,7 +207,7 @@ spec:
               db.base.memory.mb=10240
               org.gradle.jvmargs=-Dfile.encoding=UTF-8
               org.gradle.daemon=false
-              java.version=11" > gradle.properties
+              java.version=17" > gradle.properties
               """
 
               echo '---------------- Add dependencies ----------------'

--- a/pipelines/utils/Agent.yaml
+++ b/pipelines/utils/Agent.yaml
@@ -33,9 +33,11 @@ spec:
         requests:
           cpu: 1072m
           memory: 4000Mi
+          ephemeral-storage: 1Gi
         limits:
           cpu: 2072m
           memory: 6500Mi
+          ephemeral-storage: 5Gi
       volumeMounts:
         - name: rsa-keys
           mountPath: /root/.ssh/
@@ -61,6 +63,15 @@ spec:
       args:
         - --mtu=1450
         - --storage-driver=overlay2
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1000Mi
+          ephemeral-storage: 1Gi
+        limits:
+          cpu: 1000m
+          memory: 2000Mi
+          ephemeral-storage: 5Gi
       volumeMounts:
         - name: dind-storage
           mountPath: /var/lib/docker
@@ -69,4 +80,5 @@ spec:
   dnsPolicy: ClusterFirst
   serviceAccountName: default
   serviceAccount: default
+  automountServiceAccountToken: false
   securityContext: {}

--- a/pipelines/utils/Agent.yaml
+++ b/pipelines/utils/Agent.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: jenkins-node-pg-0
+  namespace: jenkins2025
+  labels:
+    app.kubernetes.io/name: jenkins-node-pg
+spec:
+  volumes:
+    - name: rsa-keys
+      configMap:
+        name: rsa-keys
+        defaultMode: 384
+    - name: dind-storage
+      emptyDir: {}
+  containers:
+    - name: compiler
+      image: etendo/compiler_jenkins:1.0.7-jdk.17.0.13
+      env:
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+      securityContext:
+        privileged: true
+        runAsUser: 0
+      ports:
+        - name: ssh
+          containerPort: 22
+          protocol: TCP
+        - name: visualvm
+          containerPort: 8000
+          protocol: TCP
+      resources:
+        requests:
+          cpu: 1072m
+          memory: 4000Mi
+        limits:
+          cpu: 2072m
+          memory: 6500Mi
+      volumeMounts:
+        - name: rsa-keys
+          mountPath: /root/.ssh/
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - bash
+              - -lc
+              - |
+                set -e
+                apt-get update -y
+                command -v docker >/dev/null || apt-get install -y docker.io
+                apt-get install -y curl
+      imagePullPolicy: IfNotPresent
+    - name: dind
+      image: docker:25-dind
+      securityContext:
+        privileged: true
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+      args:
+        - --mtu=1450
+        - --storage-driver=overlay2
+      volumeMounts:
+        - name: dind-storage
+          mountPath: /var/lib/docker
+  restartPolicy: Always
+  terminationGracePeriodSeconds: 30
+  dnsPolicy: ClusterFirst
+  serviceAccountName: default
+  serviceAccount: default
+  securityContext: {}

--- a/pipelines/utils/stackConfig.groovy
+++ b/pipelines/utils/stackConfig.groovy
@@ -1,0 +1,74 @@
+/**
+ * Extracts the major Java version number from JAVA_HOME.
+ * Supports paths like:
+ *   /usr/lib/jvm/java-17-openjdk-amd64  → "17"
+ *   /usr/lib/jvm/jdk.17.0.13            → "17"
+ *   /usr/lib/jvm/java-11-openjdk-amd64  → "11"
+ */
+String getJavaVersionNumber() {
+  def javaHome = env.JAVA_HOME ?: ''
+  def matcher = javaHome =~ /(?:java-|jdk[.-])(\d+)/
+  if (matcher.find()) {
+    return matcher.group(1)
+  }
+  return '17'
+}
+
+String getTomcatFolder() {
+  def tomcatFolder = sh(script: "basename ${TOMCAT_URL} .tar.gz", returnStdout: true).trim()
+  return tomcatFolder
+}
+
+String generateStackMessage() {
+  def tomcatFolder = env.TOMCAT_URL?.trim() ? getTomcatFolder() : null
+  def javaVersion  = env.JAVA_HOME?.trim() ? getJavaVersionNumber() : null
+
+  def msg = "<em>💡 The stack for this execution is:</em>\n<ul>\n"
+  msg += tomcatFolder ? "<li><strong>Tomcat:</strong> ${tomcatFolder}</li>\n" : ''
+  msg += javaVersion  ? "<li><strong>Java:</strong> ${javaVersion}</li>\n"   : ''
+  msg += "</ul>\n"
+  return msg
+}
+
+/**
+ * Resolves the stack configuration based on whether the branch is a backport or not.
+ *
+ * Reads from Jenkins-managed environment variables (configure in the Jenkins job):
+ *   JAVA_HOME_DEFAULT           — e.g. /usr/lib/jvm/java-17-openjdk-amd64
+ *   JAVA_HOME_BACKPORT          — e.g. /usr/lib/jvm/java-11-openjdk-amd64
+ *   TOMCAT_URL_DEFAULT          — full URL to the default Tomcat tarball
+ *   TOMCAT_URL_BACKPORT         — full URL to the backport Tomcat tarball
+ *   NEXT_CLASSIC_VERSION_DEFAULT — upper bound of etendo-core range for main builds (e.g. 26.2.0)
+ *   NEXT_CLASSIC_VERSION_BACKPORT — upper bound for backport builds (e.g. 25.3.0)
+ *   BASE_CORE_VERSION           — lower bound of etendo-core range (e.g. 24.4.0)
+ *
+ * @param fromBackport env.FROM_BACKPORT ("true"/"false")
+ * @return Map with: stackType, javaHome, tomcatUrl, nextClassicVersion, baseCoreVersion
+ */
+Map resolveStackConfiguration(String fromBackport) {
+  def stackType          = 'DEFAULT'
+  def javaHome           = env.JAVA_HOME_DEFAULT
+  def tomcatUrl          = env.TOMCAT_URL_DEFAULT
+  def nextClassicVersion = env.NEXT_CLASSIC_VERSION_DEFAULT
+  def baseCoreVersion    = env.BASE_CORE_VERSION
+
+  if (fromBackport == env.TRUE) {
+    stackType          = 'BACKPORT'
+    javaHome           = env.JAVA_HOME_BACKPORT          ?: javaHome
+    tomcatUrl          = env.TOMCAT_URL_BACKPORT         ?: tomcatUrl
+    nextClassicVersion = env.NEXT_CLASSIC_VERSION_BACKPORT ?: nextClassicVersion
+    echo "✅ Using BACKPORT stack configuration"
+  } else {
+    echo "✅ Using DEFAULT stack configuration"
+  }
+
+  return [
+    stackType         : stackType,
+    javaHome          : javaHome,
+    tomcatUrl         : tomcatUrl,
+    nextClassicVersion: nextClassicVersion,
+    baseCoreVersion   : baseCoreVersion
+  ]
+}
+
+return this


### PR DESCRIPTION
## Summary

- Fix `NEXT_CLASSIC_VERSION` from `25.3.0` to `26.2.0` — resolves `prepareConfig` failure caused by `etendo-core:26.1.0` falling outside the `[24.4.0, 25.3.0)` range
- Update Java 11 → 17: compiler image updated to `1.0.7-jdk.17.0.13`, `java.version` derived dynamically from `JAVA_HOME`
- Refactor pipeline to follow `etendo_core` pattern: extract inline pod YAML to `pipelines/utils/Agent.yaml`, add `pipelines/utils/stackConfig.groovy` to resolve stack variables (Java, Tomcat, version bounds) per branch type
- Add `-PignoreConsistency=true` to `smartbuild` to handle local source vs transitively installed JAR of the same version

## New files

| File | Purpose |
|------|---------|
| `pipelines/utils/Agent.yaml` | Pod spec extracted from Jenkinsfile |
| `pipelines/utils/stackConfig.groovy` | Resolves stack config per branch type (default / backport) |

## Jenkins job variables required

These must be configured in the Jenkins job — they are no longer hardcoded in the Jenkinsfile:

```
JAVA_HOME_DEFAULT              /usr/lib/jvm/java-17-openjdk-amd64
JAVA_HOME_BACKPORT             /usr/lib/jvm/java-11-openjdk-amd64
TOMCAT_URL_DEFAULT             https://archive.apache.org/.../apache-tomcat-9.0.98.tar.gz
TOMCAT_URL_BACKPORT            (backport Tomcat URL)
NEXT_CLASSIC_VERSION_DEFAULT   26.2.0
NEXT_CLASSIC_VERSION_BACKPORT  25.3.0
BASE_CORE_VERSION              24.4.0
BACKPORT_BRANCH                release/24.4
```

## Test plan

- [ ] Trigger pipeline on a default branch — verify `prepareConfig` and `smartbuild` succeed with Java 17
- [ ] Trigger pipeline on a backport branch (`-Y26` or `release/...`) — verify BACKPORT stack is selected
- [ ] Confirm Jenkins job has all required environment variables configured

Fixes etendosoftware/com.etendoerp.platform.extensions#96 | ETP-3629